### PR TITLE
Fix link href is URI Sheme

### DIFF
--- a/src/get-css.js
+++ b/src/get-css.js
@@ -263,10 +263,10 @@ function getCssData(options) {
             const isStyle  = node.nodeName.toLowerCase() === 'style';
 
             if (isLink && !isSkip) {
-                const isURIScheme = linkHref.indexOf("data:text/css") !== -1;
+                const isURIScheme = linkHref.indexOf('data:text/css') !== -1;
 
                 if (isURIScheme) {
-                    let cssText = decodeURIComponent(linkHref.substring(linkHref.indexOf(",") + 1));
+                    let cssText = decodeURIComponent(linkHref.substring(linkHref.indexOf(',') + 1));
 
                     if (settings.useCSSOM) {
                         cssText = Array.apply(null, node.sheet.cssRules)

--- a/src/get-css.js
+++ b/src/get-css.js
@@ -263,23 +263,37 @@ function getCssData(options) {
             const isStyle  = node.nodeName.toLowerCase() === 'style';
 
             if (isLink && !isSkip) {
-                getUrls(linkHref, {
-                    mimeType: 'text/css',
-                    onBeforeSend(xhr, url, urlIndex) {
-                        settings.onBeforeSend(xhr, node, url);
-                    },
-                    onSuccess(cssText, url, urlIndex) {
-                        // Convert relative linkHref to absolute url
-                        const sourceUrl = getFullUrl(linkHref);
+                const isURIScheme = linkHref.indexOf("data:text/css") !== -1;
 
-                        handleSuccess(cssText, i, node, sourceUrl);
-                    },
-                    onError(xhr, url, urlIndex) {
-                        cssArray[i] = '';
-                        settings.onError(xhr, node, url);
-                        handleComplete();
+                if (isURIScheme) {
+                    let cssText = decodeURIComponent(linkHref.substring(linkHref.indexOf(",") + 1));
+
+                    if (settings.useCSSOM) {
+                        cssText = Array.apply(null, node.sheet.cssRules)
+                            .map(rule => rule.cssText)
+                            .join('');
                     }
-                });
+    
+                    handleSuccess(cssText, i, node, location.href);
+                } else {
+                    getUrls(linkHref, {
+                        mimeType: 'text/css',
+                        onBeforeSend(xhr, url, urlIndex) {
+                            settings.onBeforeSend(xhr, node, url);
+                        },
+                        onSuccess(cssText, url, urlIndex) {
+                            // Convert relative linkHref to absolute url
+                            const sourceUrl = getFullUrl(linkHref);
+    
+                            handleSuccess(cssText, i, node, sourceUrl);
+                        },
+                        onError(xhr, url, urlIndex) {
+                            cssArray[i] = '';
+                            settings.onError(xhr, node, url);
+                            handleComplete();
+                        }
+                    });
+                }
             }
             else if (isStyle && !isSkip) {
                 let cssText = node.textContent;

--- a/tests/fixtures/style-uri-scheme-out.css
+++ b/tests/fixtures/style-uri-scheme-out.css
@@ -1,0 +1,1 @@
+p{color:green;}

--- a/tests/fixtures/style-uri-scheme-out.css
+++ b/tests/fixtures/style-uri-scheme-out.css
@@ -1,1 +1,0 @@
-p{color:green;}

--- a/tests/get-css.test.js
+++ b/tests/get-css.test.js
@@ -179,6 +179,21 @@ describe('get-css', function() {
             });
         });
 
+        it('returns CSS from single <link> node with URI Scheme', function(done) {
+            const URIScheme  = 'data:text/css,p%7Bcolor%3Agreen%3B%7D';
+            const expected = fixtures['style-uri-scheme-out.css'];
+
+            createTestElms(`<link rel="stylesheet" href="${URIScheme}" />`);
+
+            getCss({
+                include: '[data-test]',
+                onComplete(cssText, cssArray, nodeArray) {
+                    expect(cssText).to.equal(expected);
+                    done();
+                }
+            });
+        });
+
         it('returns CSS from single <link> node via CORS', function(done) {
             const linkProtocol = 'https:';
             const linkUrl      = `${linkProtocol}//cdn.jsdelivr.net/npm/get-css-data@1.0.0/tests/fixtures/style1.css`;
@@ -213,6 +228,20 @@ describe('get-css', function() {
             const linkUrl  = '/base/tests/fixtures/style1.css';
             const linkElms = createTestElms(`<link rel="stylesheet" href="${linkUrl}">`.repeat(2));
             const expected = fixtures['style1.css'].repeat(linkElms.length);
+
+            getCss({
+                include: '[data-test]',
+                onComplete(cssText, cssArray, nodeArray) {
+                    expect(cssText).to.equal(expected);
+                    done();
+                }
+            });
+        });
+
+        it('returns CSS from multiple <link> nodes with URI Scheme', function(done) {
+            const URIScheme  = 'data:text/css,p%7Bcolor%3Agreen%3B%7D';
+            const linkElms = createTestElms(`<link rel="stylesheet" href="${URIScheme}">`.repeat(2));
+            const expected = fixtures['style-uri-scheme-out.css'].repeat(linkElms.length);
 
             getCss({
                 include: '[data-test]',

--- a/tests/get-css.test.js
+++ b/tests/get-css.test.js
@@ -437,7 +437,7 @@ describe('get-css', function() {
             step1();
         });
 
-        it('options.useCSSOM', function(done) {
+        it('options.useCSSOM with <style>', function(done) {
             const styleCss = fixtures['style1.css'];
             const styleElm = createTestElms({ tag: 'style' })[0];
 
@@ -456,6 +456,32 @@ describe('get-css', function() {
                 useCSSOM: true,
                 onComplete(cssText, cssArray, nodeArray) {
                     expect(cssText, 'After insertRule()').to.equal(styleCss);
+                    done();
+                }
+            });
+        });
+
+        it('options.useCSSOM with data URI scheme', function(done) {
+            const encodedCSS = encodeURIComponent(fixtures['style1.css']);
+            const URIScheme  = `data:text/css;charset=UTF-8,${encodedCSS}`;
+            const styleCss = fixtures['style1.css'];
+            const styleElm = createTestElms(`<link rel="stylesheet" href="${URIScheme}" />`)[0];
+
+            getCss({
+                include: '[data-test]',
+                useCSSOM: false,
+                onComplete(cssText, cssArray, nodeArray) {
+                    expect(cssText, 'Before deleteRule()').to.equal(styleCss);
+                }
+            });
+
+            styleElm.sheet.deleteRule(0);
+
+            getCss({
+                include: '[data-test]',
+                useCSSOM: true,
+                onComplete(cssText, cssArray, nodeArray) {
+                    expect(cssText, 'After deleteRule()').to.equal('');
                     done();
                 }
             });

--- a/tests/get-css.test.js
+++ b/tests/get-css.test.js
@@ -179,9 +179,10 @@ describe('get-css', function() {
             });
         });
 
-        it('returns CSS from single <link> node with URI Scheme', function(done) {
-            const URIScheme  = 'data:text/css,p%7Bcolor%3Agreen%3B%7D';
-            const expected = fixtures['style-uri-scheme-out.css'];
+        it('returns CSS from single <link> node with data URI scheme', function(done) {
+            const encodedCSS = encodeURIComponent(fixtures['style1.css']);
+            const URIScheme  = `data:text/css;charset=UTF-8,${encodedCSS}`;
+            const expected = fixtures['style1.css'];
 
             createTestElms(`<link rel="stylesheet" href="${URIScheme}" />`);
 
@@ -238,10 +239,11 @@ describe('get-css', function() {
             });
         });
 
-        it('returns CSS from multiple <link> nodes with URI Scheme', function(done) {
-            const URIScheme  = 'data:text/css,p%7Bcolor%3Agreen%3B%7D';
+        it('returns CSS from multiple <link> nodes with data URI scheme', function(done) {
+            const encodedCSS = encodeURIComponent(fixtures['style1.css']);
+            const URIScheme  = `data:text/css;charset=UTF-8,${encodedCSS}`;
             const linkElms = createTestElms(`<link rel="stylesheet" href="${URIScheme}">`.repeat(2));
-            const expected = fixtures['style-uri-scheme-out.css'].repeat(linkElms.length);
+            const expected = fixtures['style1.css'].repeat(linkElms.length);
 
             getCss({
                 include: '[data-test]',


### PR DESCRIPTION
Hello, when we use `css-vars-ponyfill` to get the css  in IE, `<link href="data:text/css,...">` will get an error: `SCRIPT5: Access is denied.` 

I found the reason, and made changes in the code.

I also made a demo to show the problem: [css-var-ponyfill-fix-link-href-data-demo.zip](https://github.com/jhildenbiddle/get-css-data/files/8493242/css-var-ponyfill-fix-link-href-data-demo.zip).

Thank you for project.